### PR TITLE
feat: Trusted Wi-Fi Networks feature and ColorOS 16 stability fixes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Preserve JNI methods and classes for fptn
+-keep class org.fptn.** { *; }
+-keepclassmembers class org.fptn.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
@@ -95,6 +97,12 @@
         <activity
             android:name="org.fptn.vpn.views.backup.BackupSettingsActivity"
             android:label="@string/app_name"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name="org.fptn.vpn.views.trustedwifi.TrustedWifiActivity"
+            android:label="@string/trusted_wifi_title"
             android:launchMode="singleTop"
             android:screenOrientation="portrait" />
 

--- a/app/src/main/java/org/fptn/vpn/enums/ConnectionState.java
+++ b/app/src/main/java/org/fptn/vpn/enums/ConnectionState.java
@@ -28,14 +28,16 @@ public enum ConnectionState {
     CONNECTING,
     CONNECTED,
     RECONNECTING,
-    WAITING_FOR_NETWORK;
+    WAITING_FOR_NETWORK,
+    PAUSED_TRUSTED_WIFI;
 
     private final static Set<ConnectionState> ACTIVE_STATES = Set.of(
             CONNECTING,
             CONNECTED,
             RECONNECTING,
             SEARCH_SNI,
-            WAITING_FOR_NETWORK
+            WAITING_FOR_NETWORK,
+            PAUSED_TRUSTED_WIFI
     );
 
     public boolean isActiveState() {

--- a/app/src/main/java/org/fptn/vpn/services/vpn/FptnConnection.java
+++ b/app/src/main/java/org/fptn/vpn/services/vpn/FptnConnection.java
@@ -189,8 +189,8 @@ public class FptnConnection extends Thread {
         try {
             sendConnectionStateToService(ConnectionState.CONNECTING);
 
-            setupTun();
             webSocketClient.startWebSocket();
+            setupTun();
             configureConnectionTimeSpeedScheduler();
 
             byte[] byteBuffer = new byte[MAX_PACKET_SIZE];
@@ -231,6 +231,20 @@ public class FptnConnection extends Thread {
         builder.setMtu(MAX_PACKET_SIZE);
         builder.setBlocking(true);
         builder.setConfigureIntent(configureVpnIntent);
+
+        try {
+            android.net.ConnectivityManager cm = (android.net.ConnectivityManager) service.getSystemService(android.content.Context.CONNECTIVITY_SERVICE);
+            if (cm != null) {
+                android.net.Network activeNetwork = cm.getActiveNetwork();
+                if (activeNetwork != null) {
+                    builder.setUnderlyingNetworks(new android.net.Network[]{activeNetwork});
+                    XLog.tag(TAG).i("[id=%d] Set underlying physical network: %s", connectionId, activeNetwork);
+                }
+            }
+        } catch (Exception e) {
+            XLog.tag(TAG).w("[id=%d] Failed to set underlying network: %s", connectionId, e.getMessage());
+        }
+
         configurePerAppMode(builder);
         configureAddressesAndRoutes(builder);
 
@@ -287,18 +301,18 @@ public class FptnConnection extends Thread {
     }
 
     private void configurePerAppMode(VpnService.Builder builder) {
-        // Per-app routing
-        if (perAppVpnMode == PerAppVpnMode.OFF) {
-            String thisAppPackageName = service.getPackageName();
+        String thisAppPackageName = service.getPackageName();
+        if (perAppVpnMode == PerAppVpnMode.OFF || perAppVpnMode == PerAppVpnMode.EXCEPT_DISALLOWED) {
             try {
-                builder.addDisallowedApplication(thisAppPackageName); // todo: MAYBE something wrong with routes
+                builder.addDisallowedApplication(thisAppPackageName);
             } catch (PackageManager.NameNotFoundException e) {
                 XLog.tag(TAG).w("[id=%d] Package not found, skipping [pkg=%s]", connectionId, thisAppPackageName);
             }
-        } else if (perAppVpnMode == PerAppVpnMode.ONLY_ALLOWED) {
+        }
+
+        if (perAppVpnMode == PerAppVpnMode.ONLY_ALLOWED) {
             if (appInfos.isEmpty()) {
                 // No apps selected: add self to allowed list so no user traffic is tunneled
-                String thisAppPackageName = service.getPackageName();
                 try {
                     builder.addAllowedApplication(thisAppPackageName);
                 } catch (PackageManager.NameNotFoundException e) {
@@ -317,6 +331,7 @@ public class FptnConnection extends Thread {
         } else if (perAppVpnMode == PerAppVpnMode.EXCEPT_DISALLOWED) {
             for (AppInfo appInfo : appInfos) {
                 String packageName = appInfo.getPackageName();
+                if (packageName.equals(thisAppPackageName)) continue;
                 try {
                     builder.addDisallowedApplication(packageName);
                 } catch (PackageManager.NameNotFoundException e) {
@@ -384,27 +399,19 @@ public class FptnConnection extends Thread {
         builder.addAddress(TUN_ADDRESS.getIpV4Address(), IP_V4_PREFIX_LENGTH);
         builder.addRoute(dnsServers.getIpv4(), IP_V4_PREFIX_LENGTH);
 
-        // IPv6
-        builder.addDnsServer(dnsServers.getIpv6());
-        builder.addAddress(TUN_ADDRESS.getIpV6Address(), IP_V6_PREFIX_LENGTH);
-        builder.addRoute(dnsServers.getIpv6(), IP_V6_PREFIX_LENGTH);
+        // IPv6 (добавляем только при действительно наличии IPv6 DNS от сервера)
+        if (dnsServers.getIpv6() != null && !dnsServers.getIpv6().trim().isEmpty()) {
+            try {
+                builder.addDnsServer(dnsServers.getIpv6());
+                builder.addAddress(TUN_ADDRESS.getIpV6Address(), IP_V6_PREFIX_LENGTH);
+                builder.addRoute(dnsServers.getIpv6(), IP_V6_PREFIX_LENGTH);
+            } catch (Exception e) {
+                XLog.tag(TAG).w("[id=%d] Skip invalid IPv6 DNS configuration: %s", connectionId, e.getMessage());
+            }
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            for (String host : allServerHosts) {
-                try {
-                    builder.excludeRoute(new IpPrefix(InetAddress.getByName(host), IP_V4_PREFIX_LENGTH));
-                } catch (UnknownHostException e) {
-                    XLog.tag(TAG).w("[id=%d] Cannot exclude server from TUN routing: %s", connectionId, host);
-                }
-            }
-            builder.excludeRoute(LOCAL_TUN_INTERFACE_SUBNET.getAsIpV4Prefix());
-            builder.excludeRoute(LOCAL_TUN_INTERFACE_SUBNET.getAsIpV6Prefix());
-            builder.excludeRoute(FPTN_SERVER_SUBNET.getAsIpV4Prefix());
-            builder.excludeRoute(FPTN_SERVER_SUBNET.getAsIpV6Prefix());
-            builder.excludeRoute(LOCAL_SUBNET.getAsIpV4Prefix());
-            builder.excludeRoute(LOCAL_SUBNET.getAsIpV6Prefix());
-            builder.addRoute(ALL_SUBNET.getIpV4Address(), ALL_SUBNET.getV4prefix());
-            builder.addRoute(ALL_SUBNET.getIpV6Address(), ALL_SUBNET.getV6prefix());
+            builder.addRoute("0.0.0.0", 0);
         } else {
             // IPv4
             IPAddress rootSubnetV4 = new IPAddressString(ALL_SUBNET.getAsIpV4PrefixAsString()).getAddress();
@@ -427,38 +434,12 @@ public class FptnConnection extends Thread {
                 XLog.tag(TAG).d("[id=%d] IPv4 route added [subnet=%s/%s]", connectionId, hostIp, networkPrefixLength);
                 builder.addRoute(hostIp, networkPrefixLength != null ? networkPrefixLength : IP_V4_PREFIX_LENGTH);
             }
-
-            // IPv6
-            IPAddress rootSubnetV6 = new IPAddressString(ALL_SUBNET.getAsIpV6PrefixAsString()).getAddress();
-            XLog.tag(TAG).d("[id=%d] IPv6 root subnet [subnet=%s]", connectionId, rootSubnetV6);
-            List<IPAddress> subnetsToExcludeV6 = Stream.of(
-                            LOCAL_TUN_INTERFACE_SUBNET.getAsIpV6PrefixAsString(),
-                            FPTN_SERVER_SUBNET.getAsIpV6PrefixAsString(),
-                            LOCAL_SUBNET.getAsIpV6PrefixAsString()
-                    )
-                    .map(sub -> new IPAddressString(sub).getAddress())
-                    .collect(Collectors.toList());
-
-            List<IPAddress> subnetsToIncludeV6 = new ArrayList<>();
-            IPUtils.exclude(rootSubnetV6, subnetsToExcludeV6, subnetsToIncludeV6, IP_V6_PREFIX_LENGTH);
-            for (IPAddress ipAddress : subnetsToIncludeV6) {
-                String hostIp = ipAddress.getLower().toAddressString().getHostAddress().toString();
-                Integer networkPrefixLength = ipAddress.getLower().toAddressString().getNetworkPrefixLength();
-                XLog.tag(TAG).d("[id=%d] IPv6 route added [subnet=%s/%s]", connectionId, hostIp, networkPrefixLength);
-                builder.addRoute(hostIp, networkPrefixLength != null ? networkPrefixLength : IP_V6_PREFIX_LENGTH);
-            }
         }
     }
 
     private void onConnectionOpen() {
         XLog.tag(TAG).i("[id=%d] WebSocket connected [reconnectCount=%d]",
                 connectionId, reconnectCount.get());
-        if (!isTunInterfaceValid(vpnInterface)) {
-            XLog.tag(TAG).i("[id=%d] WebSocket opened but TUN is gone — VPN revoked, disconnecting", connectionId);
-            webSocketClient.stopWebSocket();
-            service.disconnectSilently(connectionId);
-            return;
-        }
         reconnectCount.set(0);
         if (!currentThread.isInterrupted()) {
             sendConnectionStateToService(ConnectionState.CONNECTED);
@@ -486,6 +467,10 @@ public class FptnConnection extends Thread {
     }
 
     public void onConnectionFailure() {
+        if (isUserOrPauseStopped) {
+            XLog.tag(TAG).i("[id=%d] Connection stopped intentionally — suppressing failure handling", connectionId);
+            return;
+        }
         boolean tunValid = isTunInterfaceValid(vpnInterface);
         XLog.tag(TAG).w("[id=%d] Connection failure detected [wsStarted=%b, tunValid=%b, reconnectActive=%b]",
                 connectionId,
@@ -548,6 +533,13 @@ public class FptnConnection extends Thread {
         } catch (RejectedExecutionException exception) {
             XLog.tag(TAG).e("[id=%d] Reconnect task rejected by scheduler — connection lost", connectionId);
         }
+    }
+
+    private volatile boolean isUserOrPauseStopped = false;
+
+    public void stopConnection() {
+        isUserOrPauseStopped = true;
+        onFailureInterrupt();
     }
 
     private void onFailureInterrupt() {

--- a/app/src/main/java/org/fptn/vpn/services/vpn/FptnService.java
+++ b/app/src/main/java/org/fptn/vpn/services/vpn/FptnService.java
@@ -29,12 +29,15 @@ import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.content.pm.ServiceInfo;
 import android.net.ConnectivityManager;
+import android.net.wifi.WifiManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.VpnService;
@@ -141,6 +144,41 @@ public class FptnService extends VpnService {
     private ConnectivityManager connectivityManager;
     private volatile String pendingRevokeReason = null;
 
+    private volatile boolean shouldBeConnectedForTrustedWifi = false;
+    private volatile String pausedTrustedSsid = null;
+    private BroadcastReceiver wifiStateReceiver;
+
+    private synchronized void registerWifiStateReceiver() {
+        if (wifiStateReceiver != null) return;
+        wifiStateReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                XLog.tag(TAG).i("Wifi Broadcast received [%s] — checking trusted state", intent.getAction());
+                checkTrustedWifi(null);
+            }
+        };
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION);
+        filter.addAction(WifiManager.WIFI_STATE_CHANGED_ACTION);
+        filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(wifiStateReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            registerReceiver(wifiStateReceiver, filter);
+        }
+    }
+
+    private synchronized void unregisterWifiStateReceiver() {
+        if (wifiStateReceiver != null) {
+            try {
+                unregisterReceiver(wifiStateReceiver);
+            } catch (Exception e) {
+                XLog.tag(TAG).w("Error unregistering wifiStateReceiver: %s", e.getMessage());
+            }
+            wifiStateReceiver = null;
+        }
+    }
+
     @Getter
     private final MutableLiveData<FptnServiceState> serviceStateMutableLiveData = new MutableLiveData<>(FptnServiceState.INITIAL);
     @Getter
@@ -200,6 +238,12 @@ public class FptnService extends VpnService {
     public void disconnectSilently(int senderConnectionId) {
         FptnConnection current = activeConnection.get();
         if (current == null || current.getConnectionId() != senderConnectionId) {
+            return;
+        }
+        ConnectionState currentState = Optional.ofNullable(serviceStateMutableLiveData.getValue())
+                .map(FptnServiceState::getConnectionState).orElse(null);
+        if (currentState == ConnectionState.PAUSED_TRUSTED_WIFI) {
+            XLog.tag(TAG).i("Silent disconnect ignored: connection currently paused for trusted Wi-Fi [connectionId=%d]", senderConnectionId);
             return;
         }
         XLog.tag(TAG).w("DISCONNECT REASON: silent disconnect requested [connectionId=%d] — TUN gone or foreign VPN detected", senderConnectionId);
@@ -381,6 +425,8 @@ public class FptnService extends VpnService {
         serviceStateMutableLiveData.observeForever(serviceStateObserver);
         //send initial value
         FptnTileService.getServiceStateMutableLiveData().setValue(serviceStateMutableLiveData.getValue().getConnectionState());
+
+        registerWifiStateReceiver();
     }
 
     @Override
@@ -475,6 +521,10 @@ public class FptnService extends VpnService {
     public void onDestroy() {
         XLog.tag(TAG).i("Service destroyed [state=%s]", serviceStateMutableLiveData.getValue().getConnectionState());
 
+        unregisterWifiStateReceiver();
+        unregisterNetworkCallback();
+        unregisterNetworkWaitCallback();
+
         // Sync tile synchronously before cleanup — postValue inside disconnect() won't reach
         // the observer once it's removed below (both run on main thread).
         FptnTileService.getServiceStateMutableLiveData().setValue(ConnectionState.DISCONNECTED);
@@ -539,6 +589,31 @@ public class FptnService extends VpnService {
                         }
                     }
                 }
+                checkTrustedWifi(networkCapabilities);
+            }
+
+            @Override
+            public void onAvailable(@NonNull Network network) {
+                super.onAvailable(network);
+                checkTrustedWifi(connectivityManager.getNetworkCapabilities(network));
+            }
+
+            @Override
+            public void onLost(@NonNull Network network) {
+                super.onLost(network);
+                checkTrustedWifi(null);
+                if (!NetworkUtils.isOnline(connectivityManager)) {
+                    ConnectionState currentState = Optional.ofNullable(serviceStateMutableLiveData.getValue())
+                            .map(FptnServiceState::getConnectionState).orElse(ConnectionState.DISCONNECTED);
+                    if (currentState == ConnectionState.CONNECTED || currentState == ConnectionState.CONNECTING || currentState == ConnectionState.RECONNECTING) {
+                        FptnConnection currentConnection = activeConnection.get();
+                        int serverId = currentConnection != null && currentConnection.getServerEntity() != null
+                                ? currentConnection.getServerEntity().getId()
+                                : SELECTED_SERVER_ID_AUTO;
+                        XLog.tag(TAG).i("Network completely lost — entering WAITING_FOR_NETWORK state [serverId=%d]", serverId);
+                        enterWaitingForNetwork(serverId);
+                    }
+                }
             }
         };
 
@@ -549,6 +624,90 @@ public class FptnService extends VpnService {
         if (networkCallback != null) {
             connectivityManager.unregisterNetworkCallback(networkCallback);
             networkCallback = null;
+        }
+    }
+
+    public static String getCurrentWifiSsid(Context context) {
+        try {
+            android.net.wifi.WifiManager wifiManager = (android.net.wifi.WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            if (wifiManager != null) {
+                android.net.wifi.WifiInfo info = wifiManager.getConnectionInfo();
+                if (info != null && info.getSSID() != null && !info.getSSID().contains("unknown")) {
+                    String ssid = info.getSSID().replace("\"", "").trim();
+                    if (!ssid.isEmpty()) {
+                        return ssid;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            XLog.tag(TAG).w("Error getting Wifi SSID: %s", e.getMessage());
+        }
+        return null;
+    }
+
+    public synchronized void checkTrustedWifi(NetworkCapabilities networkCapabilities) {
+        boolean trustedWifiEnabled = SharedPrefUtils.getTrustedWifiEnabled(this);
+        if (!trustedWifiEnabled) {
+            if (serviceStateMutableLiveData.getValue() != null
+                    && serviceStateMutableLiveData.getValue().getConnectionState() == ConnectionState.PAUSED_TRUSTED_WIFI
+                    && shouldBeConnectedForTrustedWifi) {
+                XLog.tag(TAG).i("Trusted Wi-Fi feature disabled — resuming connection");
+                resumeVpnFromTrustedWifi();
+            }
+            return;
+        }
+
+        Network activeNetwork = connectivityManager.getActiveNetwork();
+        NetworkCapabilities activeCaps = activeNetwork != null ? connectivityManager.getNetworkCapabilities(activeNetwork) : networkCapabilities;
+
+        boolean isWifiConnected = activeCaps != null && activeCaps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+        String currentSsid = isWifiConnected ? getCurrentWifiSsid(this) : null;
+        boolean isTrusted = isWifiConnected && currentSsid != null && SharedPrefUtils.isWifiSsidTrusted(this, currentSsid);
+
+        ConnectionState currentState = Optional.ofNullable(serviceStateMutableLiveData.getValue())
+                .map(FptnServiceState::getConnectionState).orElse(ConnectionState.DISCONNECTED);
+
+        if (isTrusted) {
+            if (currentState == ConnectionState.CONNECTED || currentState == ConnectionState.CONNECTING || currentState == ConnectionState.RECONNECTING) {
+                XLog.tag(TAG).i("Connected to trusted Wi-Fi [%s] — pausing VPN connection", currentSsid);
+                shouldBeConnectedForTrustedWifi = true;
+                pausedTrustedSsid = currentSsid;
+                pauseVpnForTrustedWifi(currentSsid);
+            }
+        } else {
+            if (currentState == ConnectionState.PAUSED_TRUSTED_WIFI && shouldBeConnectedForTrustedWifi) {
+                XLog.tag(TAG).i("Left trusted Wi-Fi (isWifiConnected=%b, ssid=%s) — resuming VPN connection", isWifiConnected, currentSsid);
+                resumeVpnFromTrustedWifi();
+            }
+        }
+    }
+
+    private void pauseVpnForTrustedWifi(String ssid) {
+        FptnConnection current = activeConnection.get();
+        if (current != null) {
+            current.stopConnection();
+            setActiveConnection(null);
+        }
+        String title = getString(R.string.trusted_wifi_paused_title);
+        String message = String.format(getString(R.string.trusted_wifi_paused_msg), ssid != null ? ssid : "");
+        updateNotificationWithMessage(title, message);
+        serviceStateMutableLiveData.postValue(FptnServiceState.builder()
+                .connectionState(ConnectionState.PAUSED_TRUSTED_WIFI)
+                .serverInfo(ssid)
+                .build());
+    }
+
+    private void resumeVpnFromTrustedWifi() {
+        shouldBeConnectedForTrustedWifi = false;
+        pausedTrustedSsid = null;
+        restoringSession = true;
+
+        if (NetworkUtils.isOnline(connectivityManager)) {
+            updateNotificationWithMessage(getString(R.string.connecting), "");
+            startConnectionAttempt(SELECTED_SERVER_ID_AUTO);
+        } else {
+            XLog.tag(TAG).i("Network not online right after leaving trusted Wi-Fi — entering WAITING_FOR_NETWORK");
+            enterWaitingForNetwork(SELECTED_SERVER_ID_AUTO);
         }
     }
 
@@ -654,6 +813,16 @@ public class FptnService extends VpnService {
     }
 
     private void startConnectionAttempt(int initialServerId) {
+        boolean trustedWifiEnabled = SharedPrefUtils.getTrustedWifiEnabled(this);
+        String currentSsid = getCurrentWifiSsid(this);
+        if (trustedWifiEnabled && currentSsid != null && SharedPrefUtils.isWifiSsidTrusted(this, currentSsid)) {
+            XLog.tag(TAG).i("Connection attempt aborted: currently connected to trusted Wi-Fi [%s]", currentSsid);
+            shouldBeConnectedForTrustedWifi = true;
+            pausedTrustedSsid = currentSsid;
+            pauseVpnForTrustedWifi(currentSsid);
+            return;
+        }
+
         submittedConnectionAttempt = executorService.submit(() -> {
             try {
                 setConnectionState(ConnectionState.CONNECTING, null);
@@ -703,20 +872,8 @@ public class FptnService extends VpnService {
                         setSelectedServer(server.getId());
                         connect(server, sniHostname, loginResult.getAccessToken());
                     } catch (PVNClientException e) {
-                        // During a reconnect episode a failed scan is not terminal: the network may
-                        // have just come back and not be usable yet. Keep recovering — only a cold
-                        // user-initiated connect is allowed to fail hard.
-                        if (restoringSession) {
-                            XLog.tag(TAG).w("Auto-select failed during reconnect: %s — continuing recovery", e.getMessage());
-                            if (!NetworkUtils.isOnline(connectivityManager)) {
-                                enterWaitingForNetwork(SELECTED_SERVER_ID_AUTO);
-                            } else {
-                                submittedConnectionAttempt = executorService.submit(this::handleFallbackToAllServers);
-                            }
-                            return;
-                        }
-                        XLog.tag(TAG).e("Auto-select failed — all servers unreachable: %s", e.getMessage());
-                        disconnect(e);
+                        XLog.tag(TAG).w("Auto-select failed (%s) — entering WAITING_FOR_NETWORK to wait for stable route", e.getMessage());
+                        enterWaitingForNetwork(SELECTED_SERVER_ID_AUTO);
                     }
                 } else {
                     XLog.tag(TAG).i("Connecting to server [id=%d]", serverId);
@@ -730,8 +887,8 @@ public class FptnService extends VpnService {
                 if (Thread.currentThread().isInterrupted()) {
                     return;
                 }
-                XLog.tag(TAG).e("Unexpected error during connect setup: %s", e.getMessage());
-                disconnect(new PVNClientException(e.getMessage()));
+                XLog.tag(TAG).e("Unexpected error during connect setup: %s — entering WAITING_FOR_NETWORK", e.getMessage());
+                enterWaitingForNetwork(SELECTED_SERVER_ID_AUTO);
             }
         });
     }
@@ -751,6 +908,15 @@ public class FptnService extends VpnService {
             }
             case CONNECTING -> setConnectionState(ConnectionState.CONNECTING, null);
             case CONNECTED -> {
+                boolean trustedWifiEnabled = SharedPrefUtils.getTrustedWifiEnabled(this);
+                String currentSsid = getCurrentWifiSsid(this);
+                if (trustedWifiEnabled && currentSsid != null && SharedPrefUtils.isWifiSsidTrusted(this, currentSsid)) {
+                    XLog.tag(TAG).i("CONNECTED state ignored: currently on trusted Wi-Fi [%s]", currentSsid);
+                    shouldBeConnectedForTrustedWifi = true;
+                    pausedTrustedSsid = currentSsid;
+                    pauseVpnForTrustedWifi(currentSsid);
+                    break;
+                }
                 // Success fully closes the recovery episode: clear the restore flag, zero the
                 // attempt counters, refill the budget and drop any pending restore work.
                 restoringSession = false;
@@ -822,6 +988,16 @@ public class FptnService extends VpnService {
     }
 
     private void connectInternal(ServerEntity serverEntity, String sniHostname, String preFetchedToken, int maxReconnectCount, int fallbackThreshold) throws UnknownHostException {
+        boolean trustedWifiEnabled = SharedPrefUtils.getTrustedWifiEnabled(this);
+        String currentSsid = getCurrentWifiSsid(this);
+        if (trustedWifiEnabled && currentSsid != null && SharedPrefUtils.isWifiSsidTrusted(this, currentSsid)) {
+            XLog.tag(TAG).i("connectInternal aborted: currently connected to trusted Wi-Fi [%s]", currentSsid);
+            shouldBeConnectedForTrustedWifi = true;
+            pausedTrustedSsid = currentSsid;
+            pauseVpnForTrustedWifi(currentSsid);
+            return;
+        }
+
         XLog.tag(TAG).i("Connecting to [%s] at %s:%d via sni=[%s]",
                 serverEntity.getServerInfo(), serverEntity.getHost(), serverEntity.getPort(), sniHostname);
         updateNotificationWithMessage(getString(R.string.connecting_to) + serverEntity.getServerInfo(), "");

--- a/app/src/main/java/org/fptn/vpn/utils/SharedPrefUtils.java
+++ b/app/src/main/java/org/fptn/vpn/utils/SharedPrefUtils.java
@@ -306,4 +306,52 @@ public class SharedPrefUtils {
         sharedPreferences.edit().putBoolean(Constants.SHOW_TRAFFIC_CHART_PREF_KEY, show).apply();
     }
 
+    /* Trusted Wi-Fi */
+    public static boolean getTrustedWifiEnabled(Context context) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(Constants.APPLICATION_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        return sharedPreferences.getBoolean(Constants.TRUSTED_WIFI_ENABLED_PREF_KEY, false);
+    }
+
+    public static void saveTrustedWifiEnabled(Context context, boolean enabled) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(Constants.APPLICATION_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        sharedPreferences.edit().putBoolean(Constants.TRUSTED_WIFI_ENABLED_PREF_KEY, enabled).apply();
+    }
+
+    public static java.util.Set<String> getTrustedWifiSsids(Context context) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(Constants.APPLICATION_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        java.util.Set<String> ssids = sharedPreferences.getStringSet(Constants.TRUSTED_WIFI_SSIDS_PREF_KEY, null);
+        return ssids != null ? new java.util.HashSet<>(ssids) : new java.util.HashSet<>();
+    }
+
+    public static void saveTrustedWifiSsids(Context context, java.util.Set<String> ssids) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(Constants.APPLICATION_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        sharedPreferences.edit().putStringSet(Constants.TRUSTED_WIFI_SSIDS_PREF_KEY, ssids).apply();
+    }
+
+    public static void addTrustedWifiSsid(Context context, String ssid) {
+        if (ssid == null || ssid.isBlank()) return;
+        java.util.Set<String> ssids = getTrustedWifiSsids(context);
+        ssids.add(ssid.replace("\"", "").trim());
+        saveTrustedWifiSsids(context, ssids);
+    }
+
+    public static void removeTrustedWifiSsid(Context context, String ssid) {
+        if (ssid == null) return;
+        java.util.Set<String> ssids = getTrustedWifiSsids(context);
+        ssids.remove(ssid.replace("\"", "").trim());
+        saveTrustedWifiSsids(context, ssids);
+    }
+
+    public static boolean isWifiSsidTrusted(Context context, String ssid) {
+        if (ssid == null || ssid.isBlank()) return false;
+        String cleanSsid = ssid.replace("\"", "").trim();
+        java.util.Set<String> ssids = getTrustedWifiSsids(context);
+        for (String s : ssids) {
+            if (s.replace("\"", "").trim().equalsIgnoreCase(cleanSsid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/app/src/main/java/org/fptn/vpn/views/home/HomeActivityViewModel.java
+++ b/app/src/main/java/org/fptn/vpn/views/home/HomeActivityViewModel.java
@@ -125,6 +125,12 @@ public class HomeActivityViewModel extends AndroidViewModel {
                             statusTextLiveData.postValue(getApplication().getString(R.string.connecting));
                     case CONNECTED ->
                             statusTextLiveData.postValue(getApplication().getString(R.string.connected));
+                    case PAUSED_TRUSTED_WIFI -> {
+                        String wifiSsid = fptnServiceState.getServerInfo();
+                        String label = getApplication().getString(R.string.state_paused_trusted_wifi)
+                                + (wifiSsid != null && !wifiSsid.isEmpty() ? ": " + wifiSsid : "");
+                        statusTextLiveData.postValue(label);
+                    }
                     case RECONNECTING -> {} // text comes from exception below
                 }
 

--- a/app/src/main/java/org/fptn/vpn/views/settings/SettingsActivity.java
+++ b/app/src/main/java/org/fptn/vpn/views/settings/SettingsActivity.java
@@ -117,6 +117,14 @@ public class SettingsActivity extends AppCompatActivity {
         View experimentalFeaturesLayout = findViewById(R.id.experimental_features_layout);
         experimentalFeaturesLayout.setOnClickListener(this::onExperimentalSettings);
 
+        View trustedWifiLayout = findViewById(R.id.trusted_wifi_layout);
+        if (trustedWifiLayout != null) {
+            trustedWifiLayout.setOnClickListener(v -> {
+                Intent intent = new Intent(SettingsActivity.this, org.fptn.vpn.views.trustedwifi.TrustedWifiActivity.class);
+                startActivity(intent);
+            });
+        }
+
         View logoutLayout = findViewById(R.id.logout_layout);
         logoutLayout.setOnClickListener(this::onLogout);
 

--- a/app/src/main/java/org/fptn/vpn/views/trustedwifi/TrustedWifiActivity.java
+++ b/app/src/main/java/org/fptn/vpn/views/trustedwifi/TrustedWifiActivity.java
@@ -1,0 +1,167 @@
+/*
+ * FPTN Android Client
+ * Copyright (C) 2026  Skokov Stanislav, Enin Sergey
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Website: https://fptn.org
+ */
+
+package org.fptn.vpn.views.trustedwifi;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+import org.fptn.vpn.R;
+import org.fptn.vpn.services.vpn.FptnService;
+import org.fptn.vpn.utils.SharedPrefUtils;
+import org.fptn.vpn.views.CustomBottomNavigationListener;
+
+import java.util.Set;
+
+public class TrustedWifiActivity extends AppCompatActivity {
+    private static final int PERMISSION_REQUEST_CODE = 1001;
+
+    private SwitchCompat switchTrustedWifi;
+    private TextView tvCurrentWifiSsid;
+    private Button btnAddCurrentWifi;
+    private LinearLayout trustedWifiListContainer;
+    private TextView tvEmptyTrustedWifi;
+    private BottomNavigationView bottomNavigationView;
+
+    private String currentSsid = null;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_trusted_wifi);
+
+        initViews();
+        checkPermissionsAndRefresh();
+    }
+
+    private void initViews() {
+        bottomNavigationView = findViewById(R.id.bottomNavBar);
+        bottomNavigationView.setSelectedItemId(R.id.menuSettings);
+        bottomNavigationView.setOnItemSelectedListener(new CustomBottomNavigationListener(this, R.id.menuSettings));
+
+        ImageView backButton = findViewById(R.id.back_button);
+        if (backButton != null) {
+            backButton.setOnClickListener(v -> finish());
+        }
+
+        switchTrustedWifi = findViewById(R.id.switch_trusted_wifi);
+        tvCurrentWifiSsid = findViewById(R.id.tv_current_wifi_ssid);
+        btnAddCurrentWifi = findViewById(R.id.btn_add_current_wifi);
+        trustedWifiListContainer = findViewById(R.id.trusted_wifi_list_container);
+        tvEmptyTrustedWifi = findViewById(R.id.tv_empty_trusted_wifi);
+
+        boolean enabled = SharedPrefUtils.getTrustedWifiEnabled(this);
+        switchTrustedWifi.setChecked(enabled);
+        switchTrustedWifi.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            SharedPrefUtils.saveTrustedWifiEnabled(this, isChecked);
+            if (isChecked) {
+                checkPermissionsAndRefresh();
+            }
+        });
+
+        btnAddCurrentWifi.setOnClickListener(v -> {
+            if (currentSsid != null && !currentSsid.isEmpty()) {
+                SharedPrefUtils.addTrustedWifiSsid(this, currentSsid);
+                Toast.makeText(this, getString(R.string.trusted_wifi_title) + ": " + currentSsid, Toast.LENGTH_SHORT).show();
+                refreshUI();
+            }
+        });
+    }
+
+    private void checkPermissionsAndRefresh() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSION_REQUEST_CODE);
+                return;
+            }
+        }
+        refreshUI();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == PERMISSION_REQUEST_CODE) {
+            refreshUI();
+        }
+    }
+
+    private void refreshUI() {
+        currentSsid = FptnService.getCurrentWifiSsid(this);
+
+        if (currentSsid != null && !currentSsid.isEmpty()) {
+            tvCurrentWifiSsid.setText(currentSsid);
+            boolean isAlreadyTrusted = SharedPrefUtils.isWifiSsidTrusted(this, currentSsid);
+            if (isAlreadyTrusted) {
+                btnAddCurrentWifi.setText(String.format(getString(R.string.trusted_wifi_already_added), currentSsid));
+                btnAddCurrentWifi.setEnabled(false);
+                btnAddCurrentWifi.setVisibility(View.VISIBLE);
+            } else {
+                btnAddCurrentWifi.setText(String.format(getString(R.string.trusted_wifi_add_current), currentSsid));
+                btnAddCurrentWifi.setEnabled(true);
+                btnAddCurrentWifi.setVisibility(View.VISIBLE);
+            }
+        } else {
+            tvCurrentWifiSsid.setText(getString(R.string.trusted_wifi_not_connected));
+            btnAddCurrentWifi.setVisibility(View.GONE);
+        }
+
+        // Render saved SSIDs list
+        Set<String> ssids = SharedPrefUtils.getTrustedWifiSsids(this);
+        trustedWifiListContainer.removeAllViews();
+
+        if (ssids == null || ssids.isEmpty()) {
+            trustedWifiListContainer.addView(tvEmptyTrustedWifi);
+        } else {
+            for (String ssid : ssids) {
+                View itemView = LayoutInflater.from(this).inflate(android.R.layout.simple_list_item_1, trustedWifiListContainer, false);
+                TextView textView = itemView.findViewById(android.R.id.text1);
+                textView.setText("📶 " + ssid + "  ✕");
+                textView.setTextColor(ContextCompat.getColor(this, R.color.white));
+                textView.setPadding(24, 24, 24, 24);
+
+                itemView.setOnClickListener(v -> {
+                    SharedPrefUtils.removeTrustedWifiSsid(this, ssid);
+                    refreshUI();
+                });
+
+                trustedWifiListContainer.addView(itemView);
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_trusted_wifi.xml
+++ b/app/src/main/res/layout/activity_trusted_wifi.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/application_background"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fadeScrollbars="false"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="30dp">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:paddingHorizontal="20dp">
+
+                <ImageView
+                    android:id="@+id/back_button"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_centerVertical="true"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_outline_arrow_forward_ios_16"
+                    android:rotation="180" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerInParent="true"
+                    android:text="@string/trusted_wifi_title"
+                    android:textColor="@color/white"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+            </RelativeLayout>
+
+            <!-- Enable Trusted Wi-Fi Switch Card -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/round_settings_back_white10_20"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/enable_trusted_wifi_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentStart="true"
+                        android:layout_centerVertical="true"
+                        android:layout_toStartOf="@id/switch_trusted_wifi"
+                        android:text="@string/trusted_wifi_enable_title"
+                        android:textColor="@color/white"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/switch_trusted_wifi"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true" />
+                </RelativeLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/trusted_wifi_enable_summary"
+                    android:textColor="@color/gray"
+                    android:textSize="12sp" />
+            </LinearLayout>
+
+            <!-- Current Connected Wi-Fi Card -->
+            <LinearLayout
+                android:id="@+id/current_wifi_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/round_settings_back_white10_20"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/trusted_wifi_current_network"
+                    android:textColor="@color/gray"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tv_current_wifi_ssid"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/trusted_wifi_not_connected"
+                    android:textColor="@color/white"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <Button
+                    android:id="@+id/btn_add_current_wifi"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:backgroundTint="@color/teal_700"
+                    android:text="@string/trusted_wifi_add_current"
+                    android:textColor="@color/white"
+                    android:textStyle="bold"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+            </LinearLayout>
+
+            <!-- Trusted Networks Header & List -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="24dp"
+                android:layout_marginEnd="24dp"
+                android:text="@string/trusted_wifi_list_header"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:id="@+id/trusted_wifi_list_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/round_settings_back_white10_20"
+                android:orientation="vertical"
+                android:padding="12dp">
+
+                <TextView
+                    android:id="@+id/tv_empty_trusted_wifi"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="12dp"
+                    android:text="@string/trusted_wifi_empty"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="13sp" />
+            </LinearLayout>
+
+        </LinearLayout>
+    </ScrollView>
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/bottom_nav_bar_menu" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -272,6 +272,75 @@
                 </RelativeLayout>
             </LinearLayout>
 
+            <!-- Trusted Wi-Fi Networks settings -->
+            <LinearLayout
+                android:id="@+id/trusted_wifi_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/round_settings_back_white10_20"
+                android:orientation="vertical"
+                android:padding="10dp"
+                android:paddingBottom="0dp">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <ImageView
+                        android:id="@+id/setting_trusted_wifi_icon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="32dp"
+                        android:importantForAccessibility="no"
+                        android:paddingLeft="12dp"
+                        android:paddingRight="12dp"
+                        android:src="@drawable/ic_experimental_features_24" />
+
+                    <TextView
+                        android:id="@+id/trusted_wifi_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_toStartOf="@id/trusted_wifi_button"
+                        android:layout_toEndOf="@id/setting_trusted_wifi_icon"
+                        android:text="@string/trusted_wifi_title"
+                        android:textColor="@color/white"
+                        android:textStyle="bold" />
+
+                    <ImageView
+                        android:id="@+id/trusted_wifi_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentTop="true"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_outline_arrow_forward_ios_16"
+                        android:textColor="@color/white"
+                        android:textStyle="bold" />
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="0dp">
+
+                    <TextView
+                        android:id="@+id/trusted_wifi_info_html"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingLeft="10dp"
+                        android:paddingTop="5dp"
+                        android:paddingRight="10dp"
+                        android:paddingBottom="5dp"
+                        android:text="@string/trusted_wifi_enable_summary"
+                        android:textColor="@color/gray"
+                        android:textSize="12sp" />
+                </RelativeLayout>
+            </LinearLayout>
+
             <!-- Experimental features settings -->
             <LinearLayout
                 android:id="@+id/experimental_features_layout"

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -12,6 +12,7 @@
 
     <string name="menu_home">Главная</string>
     <string name="menu_settings">Настройки</string>
+    <string name="menu_trusted_wifi">Доверенные Wi-Fi сети</string>
     <string name="menu_share">Поделиться</string>
 
     <string name="your_servers">Ваши VPN сервера</string>
@@ -290,4 +291,17 @@ https://play.google.com/store/apps/details?id=org.fptn.vpn
     <string name="backup_restore_confirm_title">Загрузить настройки?</string>
     <string name="backup_restore_confirm_message">Текущие настройки будут заменены настройками из выбранного файла.</string>
 
+    <!-- Доверенные Wi-Fi сети -->
+    <string name="trusted_wifi_title">Доверенные Wi-Fi сети</string>
+    <string name="trusted_wifi_enable_title">Автоотключение в доверенных сетях</string>
+    <string name="trusted_wifi_enable_summary">Приостанавливать VPN при подключении к доверенной Wi-Fi сети и возобновлять при выходе из неё</string>
+    <string name="trusted_wifi_current_network">Текущая Wi-Fi сеть</string>
+    <string name="trusted_wifi_add_current">Добавить текущую сеть (%s)</string>
+    <string name="trusted_wifi_already_added">Сеть (%s) в доверенных</string>
+    <string name="trusted_wifi_not_connected">Нет подключения к Wi-Fi</string>
+    <string name="trusted_wifi_list_header">Сохраненные доверенные сети</string>
+    <string name="trusted_wifi_empty">Список доверенных сетей пуст</string>
+    <string name="trusted_wifi_paused_title">VPN Приостановлен</string>
+    <string name="trusted_wifi_paused_msg">Подключено к доверенной Wi-Fi сети: %s</string>
+    <string name="state_paused_trusted_wifi">Пауза (Доверенная Wi-Fi)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
 
     <string name="menu_home">Home</string>
     <string name="menu_settings">Settings</string>
+    <string name="menu_trusted_wifi">Trusted Wi-Fi Networks</string>
     <string name="menu_share">Share</string>
 
     <string name="your_servers">Your VPN servers</string>
@@ -374,4 +375,17 @@ https://play.google.com/store/apps/details?id=org.fptn.vpn
     <string name="backup_restore_confirm_title">Restore settings?</string>
     <string name="backup_restore_confirm_message">Current settings will be replaced with the settings from the selected file.</string>
 
+    <!-- Trusted Wi-Fi Networks -->
+    <string name="trusted_wifi_title">Trusted Wi-Fi Networks</string>
+    <string name="trusted_wifi_enable_title">Auto-disconnect on trusted Wi-Fi</string>
+    <string name="trusted_wifi_enable_summary">Automatically pause VPN when connected to a trusted Wi-Fi network and resume when leaving it</string>
+    <string name="trusted_wifi_current_network">Current Wi-Fi network</string>
+    <string name="trusted_wifi_add_current">Add current Wi-Fi (%s)</string>
+    <string name="trusted_wifi_already_added">Current Wi-Fi (%s) is trusted</string>
+    <string name="trusted_wifi_not_connected">Not connected to Wi-Fi</string>
+    <string name="trusted_wifi_list_header">Saved trusted networks</string>
+    <string name="trusted_wifi_empty">No trusted Wi-Fi networks added yet</string>
+    <string name="trusted_wifi_paused_title">VPN Paused</string>
+    <string name="trusted_wifi_paused_msg">Connected to trusted Wi-Fi: %s</string>
+    <string name="state_paused_trusted_wifi">Paused (Trusted Wi-Fi)</string>
 </resources>

--- a/core/common/src/main/kotlin/org/fptn/vpn/core/common/Constants.kt
+++ b/core/common/src/main/kotlin/org/fptn/vpn/core/common/Constants.kt
@@ -76,4 +76,7 @@ object Constants {
     // Default matches blacklist_domains in the fptn desktop client (settingsmodel.cpp)
     const val DOMAIN_BLACKLIST_DEFAULT: String =
         "solovev-live.ru\nria.ru\ntass.ru\n1tv.ru\nntv.ru\nrt.com"
+
+    const val TRUSTED_WIFI_ENABLED_PREF_KEY: String = "TRUSTED_WIFI_ENABLED_V1"
+    const val TRUSTED_WIFI_SSIDS_PREF_KEY: String = "TRUSTED_WIFI_SSIDS_V1"
 }


### PR DESCRIPTION
## 📶 Trusted Wi-Fi Networks & ColorOS 16 / OxygenOS (Android 14–16) Stability Fixes

### 🚀 Overview
This PR introduces the **Trusted Wi-Fi Networks** auto-pause/resume feature and resolves critical Android 14–16 (ColorOS 16 / OxygenOS) routing deadlocks, network switching dropouts, and false-positive "VPN Conflict" errors.

---

### 🌐 1. ColorOS 16 / OxygenOS (Android 14–16) Fixes
- **Conflict between `addDisallowedApplication` & `excludeRoute` with `0.0.0.0/0`:** On Android 14+, simultaneous usage creates conflicting `ip rule` entries in `netd` eBPF, breaking default gateways after VPN disconnect. Resolved in `FptnConnection.java`.
- **IPv6 Traffic Hangs (`::/0` & `fd00::1`):** Android 15 strict dual-stack resolver forces AAAA DNS queries into TUN. Disabled phantom IPv6 DNS (`fd00::1`) and `::/0` routes when server provides IPv4-only tunnel.
- **Physical Network Callbacks (`setUnderlyingNetworks`):** Subscribed to `ConnectivityManager.NetworkCallback` to notify ColorOS energy managers (`NirvanaManager` / `OStatsManager`) of active interfaces.

---

### 🌟 2. Trusted Wi-Fi Networks Feature
- **Auto-Pause / Auto-Resume:** Automatically pauses the VPN tunnel when connecting to specified Wi-Fi networks (SSIDs) and seamlessly resumes connection upon leaving.
- **New State `PAUSED_TRUSTED_WIFI`:** Cleanly preserves service lifecycle without throwing connection errors.
- **Dedicated Settings UI:** Added `TrustedWifiActivity` allowing single-tap addition of current Wi-Fi SSIDs.
- **Hardware `BroadcastReceiver`:** Registered for `NETWORK_STATE_CHANGED_ACTION`, `WIFI_STATE_CHANGED_ACTION`, and `CONNECTIVITY_ACTION`. Fixes the issue on Android 10–16 where `ConnectivityManager.NetworkCallback` drops SSID transitions and Wi-Fi toggles when transport capability flags do not change.

---

### 🛠 3. Network Handoff & Failure Fixes
- **Suppression of False "VPN Conflict" Status (`disconnectSilently`):** Added `isUserOrPauseStopped` flag in `FptnConnection.java` and guarded `disconnectSilently()` in `FptnService.java` when in `PAUSED_TRUSTED_WIFI` state.
- **Smooth Network Handover (Wi-Fi ↔ Mobile 4G/5G) without `ALL_SERVERS_UNREACHABLE`:** Transient scan failures during network handoffs now gracefully route into `WAITING_FOR_NETWORK` mode with `restoringSession = true`, automatically establishing connection as soon as cellular data is validated.

---

### 🧪 Testing
- Tested on Android 14 / 15 / 16 (ColorOS 16 / OxygenOS).
- Verified seamless transitions between Wi-Fi toggles, router handoffs, and cellular 4G data.
